### PR TITLE
Fix standing in car bug

### DIFF
--- a/automobiles_buggy/buggy_entities.lua
+++ b/automobiles_buggy/buggy_entities.lua
@@ -618,9 +618,6 @@ minetest.register_entity("automobiles_buggy:buggy", {
 
         if stop ~= true then
             --self.object:set_velocity(velocity)
-            if player then
-                automobiles_lib.attach_driver(self, player)
-            end
             self.object:set_acceleration(accel)
         else
             if stop == true then

--- a/automobiles_coupe/coupe_entities.lua
+++ b/automobiles_coupe/coupe_entities.lua
@@ -646,9 +646,6 @@ minetest.register_entity("automobiles_coupe:coupe", {
 
         if stop ~= true then
             --self.object:set_velocity(velocity)
-            if player then
-                automobiles_lib.attach_driver(self, player)
-            end
             self.object:set_acceleration(accel)
         else
             if stop == true then

--- a/automobiles_lib/init.lua
+++ b/automobiles_lib/init.lua
@@ -79,13 +79,26 @@ function automobiles_lib.attach_driver(self, player)
     end
     player:set_eye_offset({x = 0, y = eye_y, z = 0}, {x = 0, y = eye_y, z = -30})
     player_api.player_attached[name] = true
-    -- make the driver sit
+
+    -- Make the driver sit
+    -- Minetest bug: Animation is not always applied on the client.
+    -- So we try sending it twice.
+    -- We call set_animation with a speed on the second call
+    -- so set_animation will not do nothing.
+    player_api.set_animation(player, "sit")
+
     minetest.after(0.2, function()
         player = minetest.get_player_by_name(name)
         if player then
-            --player:set_properties({physical=false})
-	        player_api.set_animation(player, "sit")
-            --apply_physics_override(player, {speed=0,gravity=0,jump=0})
+            local speed = 30.01
+            local mesh = player:get_properties().mesh
+            if mesh then
+                local character = player_api.registered_models[mesh]
+                if character and character.animation_speed then
+                    speed = character.animation_speed + 0.01
+                end
+            end
+            player_api.set_animation(player, "sit", speed)
         end
     end)
 end

--- a/automobiles_lib/mod.conf
+++ b/automobiles_lib/mod.conf
@@ -1,2 +1,2 @@
 name = automobiles_lib
-depends=biofuel,mobkit
+depends=biofuel,mobkit,player_api

--- a/automobiles_roadster/roadster_entities.lua
+++ b/automobiles_roadster/roadster_entities.lua
@@ -591,9 +591,6 @@ minetest.register_entity("automobiles_roadster:roadster", {
 
         if stop ~= true then
             --self.object:set_velocity(velocity)
-            if player then
-                automobiles_lib.attach_driver(self, player)
-            end
             self.object:set_acceleration(accel)
         else
             if stop == true then


### PR DESCRIPTION
Some times the sit animation is not applied when attaching a player to a car. If you try getting in and out of a car a few times you will notice. This PR fixes this problem by setting the animation 2 times. I did a fair amount of testing and never saw it fail.

This PR also adds player_api to the dependencies since it does seem to depend of player_api

Previously the code was attaching a riding player to the car every tick. This PR fixes that so it only attaches the player once.