### PR TITLE
Make painter form scrollbars draggable

### DIFF
--- a/automobiles_lib/painter.lua
+++ b/automobiles_lib/painter.lua
@@ -43,20 +43,6 @@ local function rgb_to_hex(r, g, b)
 	return string.format("#%02X%02X%02X", r, g, b)
 end
 
--- Need to convert between 1000 units and 256
-local function from_slider_rgb(value)
-	value = tonumber(value)
-	return math.floor((255/1000*value)+0.5)
-end
-
--- ...and back
-local function to_slider_rgb(value)
-    if value then
-    	return 1000/255*value
-    end
-    return 1000/255*255
-end
-
 -- Painter formspec
 local function painter_form(itemstack, player)
 	local meta = itemstack:get_meta()
@@ -75,22 +61,30 @@ local function painter_form(itemstack, player)
 		"label[0,0;Preview:]"..
 		"image[1.2,0;2,2;automobiles_painting.png^[colorize:"..color..":255]"..
 		-- RGB sliders
-		"scrollbar[0,2;5,0.3;horizontal;r;"..tostring(to_slider_rgb(rgb.r)).."]"..
-		"label[5.1,1.9;R: "..tostring(rgb.r).."]"..
-		"scrollbar[0,2.6;5,0.3;horizontal;g;"..tostring(to_slider_rgb(rgb.g)).."]"..
-		"label[5.1,2.5;G: "..tostring(rgb.g).."]"..
-		"scrollbar[0,3.2;5,0.3;horizontal;b;"..tostring(to_slider_rgb(rgb.b)).."]"..
-		"label[5.1,3.1;B: "..tostring(rgb.b).."]"..
+		"scrollbaroptions[min=0;max=255]"..
+		"scrollbar[0,2;5,0.3;horizontal;r;"..rgb.r.."]"..
+		"label[5.1,1.9;R: "..rgb.r.."]"..
+		"scrollbar[0,2.6;5,0.3;horizontal;g;"..rgb.g.."]"..
+		"label[5.1,2.5;G: "..rgb.g.."]"..
+		"scrollbar[0,3.2;5,0.3;horizontal;b;"..rgb.b.."]"..
+		"label[5.1,3.1;B: "..rgb.b.."]"..
 		-- Hex field
 		"field[0.3,4.5;2,0.8;hex;Hex Color;"..color.."]"..
 		"button[4.05,4.1;2,1;set;Set color]"
 	)
 end
 
+local formspec_timers = {}
+
 minetest.register_on_player_receive_fields(function(player, formname, fields)
 	if formname == "automobiles_lib:painter" then
+		if formspec_timers[player] then
+			formspec_timers[player]:cancel()
+			formspec_timers[player] = nil
+		end
+
 		local itemstack = player:get_wielded_item()
-		if fields.set then
+		if fields.set or fields.quit then
 			if itemstack:get_name() == "automobiles_lib:painter" then
 				local meta = itemstack:get_meta()
 				local hex = fields.hex
@@ -103,24 +97,35 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 				    meta:set_string("description", "Automobiles Painter ("..hex:upper()..")")
 				    player:set_wielded_item(itemstack)
 				    painter_form(itemstack, player)
-				    return
                 end
 			end
-		end
-		if fields.r or fields.g or fields.b then
+		elseif fields.r or fields.g or fields.b then
 			if itemstack:get_name() == "automobiles_lib:painter" then
 				-- Save on slider adjustment (hex/alpha will adjust to match the rgba!)
 				local meta = itemstack:get_meta()
 				local function sval(value)
-					return from_slider_rgb(value:gsub(".*:", ""))
+					local num = math.floor(tonumber((value:gsub(".*:", ""))) or 0)
+					if num > 255 or num < 0 then num = 0 end
+					return num
 				end
 				meta:set_string("paint_color", rgb_to_hex(sval(fields.r),sval(fields.g),sval(fields.b)))
 				-- Keep track of what this painter is painting
 				meta:set_string("description", "Automobiles Painter ("..meta:get_string("paint_color"):upper()..")")
-				player:set_wielded_item(itemstack)
-				painter_form(itemstack, player)
+				
+				formspec_timers[player] = minetest.after(0.2, function(itemstack, name)
+					local player = minetest.get_player_by_name(name)
+					if player then
+						local wield = player:get_wielded_item()
+						if wield:get_name() == itemstack:get_name() then
+							player:set_wielded_item(itemstack)
+							painter_form(itemstack, player)
+						end
+					end
+					formspec_timers[player] = nil
+				end, itemstack, player:get_player_name())
 			end
 		end
+		return true
 	end
 end)
 --[[end of adaptations]]--


### PR DESCRIPTION
This PR make painter form scroll bars draggable The problem is that if you resend the player the formspec, their scrollbar drag will end. Scrollbars produce constant output when they are being dragged so you can't resend the formspec whenever getting scrollbar changes. The solution is to set a timer. If the player moves the scrollbar again, cancel the timer. When the timer expires resend the formspec. I used this technique in my edit_skin mod.

Other changes:
- removed from/to_slider_rgb in favor of setting the scrollbar range directly.
- return true from on_player_receive_fields if it is the painter formspec so no other callbacks will be called.
- Set the color from the hex field when enter is pressed instead of doing nothing.

Other problems with painter (this PR does not fix):
- If you use a painter on a car without setting a color you get a warning.
- This file is a mix of tabs and spaces. Mostly tabs. I would have converted it to all spaces to be consistent with the rest of the mod but then the diff would be useless so that will need to be a different PR.
- UI is bad. Before looking at the code I thought you had to press set color whenever changing the color. but actually you only need to do it if setting the hex field. Also the scrollbars are very narrow.