### PR TITLE
Use add_velocity instead of set_velocity, to get rid of movement jitter

### DIFF
--- a/automobiles_lib/custom_physics.lua
+++ b/automobiles_lib/custom_physics.lua
@@ -7,9 +7,9 @@ function automobiles_lib.physics(self)
 		-- dumb friction
 	if self.isonground and not self.isinliquid then
         --minetest.chat_send_all('okay')
-		self.object:set_velocity({x=vel.x*friction,
-								y=vel.y,
-								z=vel.z*friction})
+		self.object:add_velocity({x=vel.x - vel.x*friction,
+					  y=0,
+					  z=vel.z - vel.z*friction})
 	end
 	
 	-- bounciness
@@ -33,7 +33,7 @@ function automobiles_lib.physics(self)
 			self.collided = false
 		end
 		
-		self.object:set_velocity(vnew)
+		self.object:add_velocity(vector.subtract(vel, vnew))
 	end
 	
 	-- buoyancy

--- a/automobiles_lib/ground_detection.lua
+++ b/automobiles_lib/ground_detection.lua
@@ -98,7 +98,8 @@ function automobiles_lib.ground_get_distances(self, radius, axis_distance)
                 self._last_front_detection = rear_obstacle_level.y
                 --here we need to set the collision effect
                 self.object:set_acceleration({x=0,y=0,z=0})
-                self.object:set_velocity({x=0,y=0,z=0})
+		local oldvel = self.object:get_velocity()
+                self.object:add_velocity(vector.subtract(vector.new(), oldvel))
             end
         end
 


### PR DESCRIPTION
Was looking into porting bits of this to Exile, as our vehicles' controls are kind of terrible, but I saw an easy fix that your code could benefit from. Using add_velocity() instead of set_velocity() prevents desynchronization between client and server that can cause jittering movement. 
This patch applies that to the three places where automobiles_lib formerly used set_velocity. Tested with a lovely drive on one of our dev servers.