### PR TITLE
Fixed issue on mineclonia related to player_api not found

### DIFF
--- a/automobiles_lib/entities.lua
+++ b/automobiles_lib/entities.lua
@@ -78,7 +78,9 @@ function automobiles_lib.on_rightclick (self, clicker)
         else
             --minetest.chat_send_all("clicou")
             --a passenger
-            if not player_api.player_attached[name] then
+
+            if (automobiles_lib.is_minetest and not player_api.player_attached[name]) or
+			     (airutils.is_mcl and mcl_player.player_attached[name]) then
                 --there is no passenger, so lets attach
                 if self.driver_name then
                     local attach_pax_f = automobiles_lib.attach_pax


### PR DESCRIPTION
After 0d2ef538215fdf0c9874c3eadf86c813054ae189 it started working fine on mineclonia, but when right-clicking sometimes it exploded because of player_api not found. This was the exact error when my 6yo kid clicked on my fusca:

```
2025-05-12 20:01:07: ACTION[Server]: Pupito right-clicks object 475: LuaEntitySAO "automobiles_beetle:beetle" at (615,6,-81)
2025-05-12 20:01:07: WARNING[Server]: Undeclared global variable "player_api" accessed at /data/mods/automobiles_pck/automobiles_lib/entities.lua:81
```

After this change, it works fine, and we were playing with that for a while.